### PR TITLE
updated team_members information link

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -26,8 +26,8 @@ class FeedbacksController < ApplicationController
   end
 
   private
+
   def feedback_params
     params.require(:feedback).permit(:content, :query)
-    # params[:team_member].permit(:users).require(:first_name, :email)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,7 @@ class PagesController < ApplicationController
   private
 
   def parsed_members
-    url = 'https://juliet-tech.github.io/popularis-api/team/team_members.json'
+    url = 'https://raw.githubusercontent.com/juliet-tech/popularis-api/master/team/team_members.json'
     serialized_team = open(url).read
     members_json = JSON.parse(serialized_team)
   end

--- a/app/controllers/sentences_controller.rb
+++ b/app/controllers/sentences_controller.rb
@@ -15,7 +15,6 @@ class SentencesController < ApplicationController
       OR bodies.category @@ :query
   		"
 
-      # Try putting % % around :query -> https://sqlbolt.com/lesson/select_queries_with_constraints_pt_2
   		@sql_results = Sentence.joins(:bodies).where(sql_query, query: "%#{params[:query]}%")
       @query_qty = @sql_results.each_with_object(Hash.new(0)) { |sentence, counts| counts[sentence] += 1 }
       @sorted_sentences = @query_qty.sort_by { |sentence, qty| qty }.reverse


### PR DESCRIPTION
Changed the link so that it feeds off of github's raw content api and can access it quicker, than having github deploy to ghpages and then feed off the information to the platform